### PR TITLE
FIR-21652: Switch to microseconds resolution for ORC import of timestamps

### DIFF
--- a/cpp/src/arrow/adapters/orc/adapter_util.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_util.cc
@@ -215,13 +215,13 @@ Status AppendTimestampBatch(liborc::ColumnVectorBatch* column_vector_batch,
     // Convert ORC's timestamp column with a resolution of nanoseconds to Arrow's
     // timestamp column with a resolution of microseconds by truncating to microseconds.
     int64_t seconds_us;
-    if (__builtin_smull_overflow(seconds[index], kOneSecondMicros, &seconds_us)) {
+    if (__builtin_smull_overflow(seconds[index], kOneSecondMicros, &seconds_us)) { [[unlikely]]
       error_message =
           "Overflow in ORC reader during conversion from seconds to microseconds";
     }
     const int64_t subseconds_us = nanos[index] / kOneMicroNanos;
     int64_t result;
-    if (__builtin_saddl_overflow(seconds_us, subseconds_us, &result)) {
+    if (__builtin_saddl_overflow(seconds_us, subseconds_us, &result)) { [[unlikely]]
       error_message =
           "Overflow in ORC reader when adding the microseconds to the seconds";
     }


### PR DESCRIPTION
## Summary:

ORC stores timestamps in up to 128 bits with a resolution of nanoseconds. Arrow originally mapped that to its 64-bit timestamp type with a resolution of nanoseconds. An unfortunate consequence was that Arrow only supported the range between 1677-09-21 00:12:43 and 2262-04-11 23:47:16, which was less than the range supported by ORC and Firebolt. As Firebolt only supports a resolution of microseconds, we switched to Arrow's 64-bit timestamp type with microseconds resolution. Now, we do support the same range as Firebolt's timestamp type.
The main changes related to this PR happen in the Arrow submodule. Please review that change.

## Test Plan:

There was already an integration test testing the limited range supported until now. I extended that test to check that we now support the same range as Firebolt's TIMESTAMPNTZ type. I watched this test fail before my changes in the Arrow submodule and pass after my changes.

See https://github.com/firebolt-analytics/packdb/pull/4506