### PR TITLE
fix(thrift): add TEnumIterator::operator== for libc++ 22

### DIFF
--- a/third_party/thrift/lib/cpp/src/thrift/Thrift.h
+++ b/third_party/thrift/lib/cpp/src/thrift/Thrift.h
@@ -61,6 +61,15 @@ public:
     return (ii_ != n_);
   }
 
+  // libc++ >= 19 implements std::map's range constructor with `first == last`; TEnumIterator only
+  // declared operator!=, so std::map<int,const char*>(TEnumIterator,...) failed to compile under the
+  // LLVM 22 toolchain ("invalid operands to binary expression"). Provide the matching ==.
+  bool operator==(const TEnumIterator& end) const {
+    THRIFT_UNUSED_VARIABLE(end);
+    assert(end.n_ == -1);
+    return (ii_ == n_);
+  }
+
   std::pair<int, const char*> operator*() const { return std::make_pair(enums_[ii_], names_[ii_]); }
 
 private:


### PR DESCRIPTION
**Background**

PackDB is migrating its CMake build to Clang 22 + libc++ 22 (FB-1819). libc++ >= 19 implements
std::map's range constructor with \`first == last\`.

**Summary**

arrow's vendored thrift \`TEnumIterator\` only declared \`operator!=\`, so
\`std::map<int,const char*>(TEnumIterator,...)\` in the generated \`parquet_types.cpp\` failed to compile
under the LLVM 22 toolchain. Add the matching \`operator==\`.

**Test Plan**

- parquet_static compiles under clang-22 + libc++22 in the packdb FB-1819 branch.