### PR TITLE
fix(json): bound JSON reader nesting depth to prevent stack overflow (FB-2936)

### DIFF
--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -827,7 +827,7 @@ class HandlerBase : public BlockParser,
     }
     auto struct_builder = Cast<kind>(builder_);
     absent_fields_stack_.Push(struct_builder->num_fields(), true);
-    StartNested();
+    RETURN_NOT_OK(StartNested());
     return struct_builder->Append();
   }
 
@@ -881,7 +881,7 @@ class HandlerBase : public BlockParser,
     if (ARROW_PREDICT_FALSE(builder_.kind != kind)) {
       return IllegallyChangedTo(kind);
     }
-    StartNested();
+    RETURN_NOT_OK(StartNested());
     // append to the list builder in EndArrayImpl
     builder_ = Cast<kind>(builder_)->value_builder();
     return Status::OK();
@@ -897,10 +897,20 @@ class HandlerBase : public BlockParser,
   /// helper method for StartArray and StartObject
   /// adds the current builder to a stack so its
   /// children can be visited and parsed.
-  void StartNested() {
+  ///
+  /// Rejects input nested deeper than kMaxNestingDepth. The RapidJSON parse itself is iterative
+  /// (kParseIterativeFlag) and cannot overflow, but the array/struct builders are finalized
+  /// recursively (RawArrayBuilder<kArray|kObject>::Finish / RawBuilderSet::Finish), so deeply
+  /// nested input would otherwise overflow the native stack. Guarding here — the single point where
+  /// built (non-skipped) nesting deepens for both objects and arrays — makes that unreachable.
+  Status StartNested() {
+    if (ARROW_PREDICT_FALSE(builder_stack_.size() >= kMaxNestingDepth)) {
+      return Status::Invalid("JSON nesting depth exceeds the maximum of ", kMaxNestingDepth);
+    }
     field_index_stack_.push_back(field_index_);
     field_index_ = -1;
     builder_stack_.push_back(builder_);
+    return Status::OK();
   }
 
   /// helper method for EndArray and EndObject
@@ -927,6 +937,11 @@ class HandlerBase : public BlockParser,
     }
     return scalar_values_builder_.ReserveData(size - available_storage);
   }
+
+  // Maximum object/array nesting depth accepted before StartNested() rejects the input, to keep
+  // the recursive builder finalization (RawArrayBuilder::Finish / RawBuilderSet::Finish) from
+  // overflowing the native stack on deeply nested JSON.
+  static constexpr size_t kMaxNestingDepth = 1000;
 
   Status status_;
   RawBuilderSet builder_set_;


### PR DESCRIPTION
## Summary
Fixes **FB-2936** — an unauthenticated remote crash (stack-overflow SIGSEGV) in the Arrow C++ JSON reader on deeply nested JSON. Firebolt's `read_json()` (and JSON external tables / `COPY FROM`) reach this via schema inference; any read-only query over an attacker-supplied JSON file can take down the engine process.

## Root cause
`arrow::json`'s block parser runs RapidJSON **iteratively** (`kParseIterativeFlag`), so parsing deep JSON is stack-safe. But the array/struct builders are **finalized recursively** — `RawArrayBuilder<Kind::kArray|kObject>::Finish` ⇄ `RawBuilderSet::Finish` recurse one native frame per nesting level with no depth guard. Deeply nested input (`{"a":{"a":{…}}}` or `[[[…]]]`, ~20k levels) overflows the thread stack during finalization, before any limit can fire. `ParseOptions` exposes no depth cap (checked against upstream `main` too).

## Fix
Reject input nested deeper than `kMaxNestingDepth` (1000) in `HandlerBase::StartNested()` — the single point where *built* (non-skipped) object/array nesting deepens, shared by every handler (`InferType`/`Ignore`/`Error`) via `StartObjectImpl`/`StartArrayImpl`. `builder_stack_.size()` is the live depth; on exceed we return `Status::Invalid`, which aborts the (already-iterative) parse cleanly. Skipped subtrees don't build and can't drive the `Finish` recursion, so guarding built nesting is sufficient. This mirrors the existing `fix(thrift): restore skip() recursion-depth guard` patch.

Three lines of behavior change at one choke point; ~1 comparison per nested container (negligible).

## Validation
Built Firebolt with this patch and its packdb-side guard removed, then ran the JSON inference SQL suite:
- A 2000-level document is now rejected gracefully (`JSON nesting depth exceeds the maximum of 1000`) instead of SIGSEGV.
- `read_json`, `read_files`, `read_relative_path`, and external-table JSON tests all pass unchanged.

## Notes
- 1000 is a hardcoded constant here (consistent with Firebolt's other JSON depth limits; simdjson's default is 1024). If we want it tunable, it can be promoted to a `ParseOptions::max_nesting_depth` field — that's also the form to propose upstream to apache/arrow, which has the same gap.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 83b978e7ed5494bab0e593945f151b2a594ceb9e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->