### PR TITLE
fix(json): reject a root-level `null` instead of reading off an empty builder stack (FB-3289)

### DIFF
--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -672,6 +672,16 @@ class HandlerBase : public BlockParser,
   ///
   /// @{
   bool Null() {
+    // A document whose root value is `null` reaches this with no enclosing object
+    // or array, so builder_stack_ is still empty and there is no parent builder to
+    // append to. The other scalar handlers reject a scalar root via the
+    // builder_.kind mismatch below, but this one dereferences the parent
+    // unconditionally, so guard it explicitly rather than reading off the front of
+    // the stack.
+    if (ARROW_PREDICT_FALSE(builder_stack_.empty())) {
+      status_ = IllegallyChangedTo(Kind::kNull);
+      return status_.ok();
+    }
     status_ = builder_set_.AppendNull(builder_stack_.back(), field_index_, builder_);
     return status_.ok();
   }


### PR DESCRIPTION
**Background**

Firebolt's `json_schema_infer` libFuzzer target (which drives `DB::JSONSchemaReader::readSchema`, the schema-inference path behind `read_json`, `read_files` over JSON, JSON external tables and `COPY FROM`) reported an ASan heap-buffer-overflow: `READ of size 8` at 8 bytes *before* a 16-byte `vector<BuilderPtr>` allocation, inside `HandlerBase::Null()`.

**Summary**

`HandlerBase::Null()` passed `builder_stack_.back()` to `AppendNull()` without checking that the stack was non-empty. `builder_stack_` starts empty — `Initialize()` puts the root struct builder in `builder_`, and `StartNested()` is the only thing that ever pushes — so a document whose root value is a bare `null` read element `[-1]`, eight bytes before the vector's buffer.

The sibling scalar handlers are unaffected, which is exactly why this went unnoticed: `Bool()`, `RawNumber()` and `String()` only inspect `builder_.kind` and return `IllegallyChangedTo(...)` for a scalar root, never touching the parent. `Null()` was the one handler that dereferenced the parent before any root-shape validation could run — and `Handler<InferType>`, the configuration Firebolt's inference uses, inherits it unchanged.

The fix guards the empty stack and returns `IllegallyChangedTo(Kind::kNull)`, producing the same shape of error the other root-level scalars already produce (`Column() changed from object to null in row 0`).

This is reachable as a denial of service, not only as a sanitizer finding: in a non-sanitized release build the garbage `BuilderPtr` sends the reader into a hang rather than a crash, so any query that infers a schema from untrusted JSON can wedge the process.

**Test Plan**

- Reproducer `printf 'null\n' > t.json`, previously a >60s hang in a release build, now returns `Column() changed from object to null in row 0`. The original 2171-byte fuzzer reproducer likewise returns cleanly.
- Legal nulls unaffected: `{"a":null}` (struct parent) and `[null]` (array parent) still infer normally, and `123` / `{"a":1}` are unchanged.
- Firebolt's JSON SQL suites pass with the patched submodule: 78 tests locally and 83 with MinIO, zero failures. New fixtures covering a null-only file, a root `null` between well-formed objects, and nulls as array elements are added on the Firebolt side.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches JSON parsing used for schema inference on untrusted input; the change is a small defensive guard that closes a DoS/OOB path rather than altering successful parse behavior.
> 
> **Overview**
> Fixes a heap-buffer-overflow (and a release-build hang) in the JSON block parser when the document root is a bare `null`.
> 
> `HandlerBase::Null()` used to call `builder_stack_.back()` with an empty stack. Other scalar handlers already reject a scalar root via a kind mismatch; this path now does the same with `IllegallyChangedTo(Kind::kNull)` so inference/parse of untrusted JSON fails cleanly instead of reading off the vector or wedging.
> 
> Adds `FailOnRootLevelNull` covering a lone `null` and a `null` after a valid object. Nested/field-level nulls are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a65d0528e6c1ed04211a6d9a075ac6a771bd9583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->